### PR TITLE
fix[#94]: triggered reaction when request for time-discord area from web front

### DIFF
--- a/server/services/discord/main.go
+++ b/server/services/discord/main.go
@@ -2,20 +2,21 @@ package main
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
-	"net/url"
-	"database/sql"
 	"time"
+
 	// "io/ioutil"
 
+	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
-	"github.com/dgrijalva/jwt-go"
 	_ "github.com/lib/pq"
 )
 
@@ -28,7 +29,7 @@ const PERMISSIONS = 8 // 2080
 const EXPIRATION = 60 * 30
 
 type Objects struct {
-	Channel int `json:"channel"`
+	Channel string `json:"channel"`
 	Message string `json:"message"`
 }
 
@@ -73,7 +74,7 @@ func setOAUTHToken(w http.ResponseWriter, req *http.Request, db *sql.DB) {
 	var user UserResult
 	var tokid int
 	var owner = -1
-	
+
 	// make the request to discord api
 	clientid := os.Getenv("DISCORD_ID")
 	clientsecret := os.Getenv("DISCORD_SECRET")
@@ -88,7 +89,7 @@ func setOAUTHToken(w http.ResponseWriter, req *http.Request, db *sql.DB) {
 	data.Set("grant_type", "authorization_code")
 	data.Set("code", res.Code)
 	data.Set("redirect_uri", "https://area-jeepg.vercel.app/connected")
-	rep, err := http.PostForm(API_OAUTH, data);
+	rep, err := http.PostForm(API_OAUTH, data)
 	if err != nil {
 		fmt.Fprintln(w, "postform", err.Error())
 		return
@@ -106,7 +107,7 @@ func setOAUTHToken(w http.ResponseWriter, req *http.Request, db *sql.DB) {
 		fmt.Fprintln(w, "request error", err.Error())
 		return
 	}
-	req.Header.Set("Authorization", "Bearer " + tok.Token)
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
 	client := &http.Client{}
 	rep, err = client.Do(req)
 	if err != nil {
@@ -142,12 +143,12 @@ func setOAUTHToken(w http.ResponseWriter, req *http.Request, db *sql.DB) {
 
 	// create the token
 	secretBytes := []byte(os.Getenv("BACKEND_KEY"))
-    claims := jwt.MapClaims{
-        "id": owner,
-        "exp": time.Now().Add(time.Second * EXPIRATION).Unix(),
-    }
-    token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-    tokenStr, err := token.SignedString(secretBytes)
+	claims := jwt.MapClaims{
+		"id":  owner,
+		"exp": time.Now().Add(time.Second * EXPIRATION).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenStr, err := token.SignedString(secretBytes)
 	if err != nil {
 		fmt.Fprintln(w, "sign", err.Error())
 		return
@@ -179,7 +180,7 @@ func doSomeSend(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, "{ \"error\": \"%s\" }\n", err.Error())
 		return
 	}
-	channel := strconv.Itoa(content.Dishes.Channel)
+	channel := content.Dishes.Channel
 	fmt.Println(channel, data["content"])
 	rep, err := http.NewRequest("POST", API_SEND+channel+"/messages", bytes.NewBuffer(dataBytes))
 	if err != nil {
@@ -187,7 +188,7 @@ func doSomeSend(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, "{ \"error\": \"%s\" }\n", err.Error())
 		return
 	}
-	rep.Header.Set("Authorization", "Bot " + token)
+	rep.Header.Set("Authorization", "Bot "+token)
 	rep.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	res, err := client.Do(rep)

--- a/server/src/routes/arearoute/newarea.go
+++ b/server/src/routes/arearoute/newarea.go
@@ -127,5 +127,8 @@ func NewArea(a area.AreaRequest) {
 		a.Error(err, http.StatusInternalServerError)
 		return
 	}
-	fmt.Fprintf(a.Writter, "Your email is %d, Awnser is %s", id, string(body))
+	a.Reply(map[string]any{
+		"res": "Your email is send" + string(body) + " " + string(id),
+	}, http.StatusOK)
+	// fmt.Fprintf(a.Writter, "Your email is %d, Awnser is %s", id, string(body))
 }

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="AREA website, the easiest way of creating your own automations"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!-- <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> -->
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/web/src/area/discord/AreaDiscord1.js
+++ b/web/src/area/discord/AreaDiscord1.js
@@ -115,14 +115,14 @@ export default function AreaDiscord1() {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                "Authorization": "Bearer " + sessionStorage.getItem("token")
+                "Authorization": "Bearer " + sessionStorage.getItem("token"),
             },
             body: JSON.stringify({
                 action: {
                     service: "time",
                     name: "in",
                     spices: {
-                        howmuch: time,
+                        howmuch: parseInt(time, 10),
                         unit: unit
                     }
                 },
@@ -178,7 +178,7 @@ export default function AreaDiscord1() {
                     <div className="flex items-center m-5">
                         <label className="text-[#7289da] mr-3 font-spartan font-bold text-lg">Channel</label>
                         <input
-                            type="text"
+                            type="number"
                             id="channel"
                             value={channel}
                             onChange={(e) => setChannel(e.target.value)}

--- a/web/src/utils/fetchData.js
+++ b/web/src/utils/fetchData.js
@@ -10,14 +10,12 @@ export default async function fetchData(url, request = {method: "GET"}) {
     try {
         const res = await fetch(url, request);
         if (!res.ok) {
-            console.error(`Response status: ${res}`);
-            throw new Error(`Response status: ${res}`);
+            throw res.statusText;
         }
     
         const json = await res.json();
         return { success: true, data: json };
     } catch (err) {
-        console.error(`Error while fetching data: ${err}`);
         return { success: false, error: err };
     }
 }


### PR DESCRIPTION
# Fix request for `time-discord` area 

Fix error when sending a request to create an area with `time` and `discord` services from the front.
The request is sending, the response is return and valid.

But the reaction is not triggered.

Need to fix this issue !

> close #94