### PR TITLE
123 backend implementation

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -180,14 +180,14 @@ services:
     networks:
       - web
     volumes:
-    - ./server/services/github/.env:/usr/mount.d/.env
+    - ./services/github/.env:/usr/mount.d/.env
   
   service-reddit:
     env_file:
       - .env
     container_name: area-service-reddit
     build:
-      context: ./server/services/reddit
+      context: ./services/reddit
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.reddit.rule=PathPrefix(`/service/reddit/`)"

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     networks:
       - web
     volumes:
-      - ./services:${BACKEND_SERVICES_PATH}
+      - ./server/services:${BACKEND_SERVICES_PATH}
 
   database:
     env_file:
@@ -49,7 +49,7 @@ services:
       - .env
     container_name: area-service-discord
     build:
-      context: ./services/discord
+      context: ./server/services/discord
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.discord.rule=PathPrefix(`/service/discord/`)"
@@ -67,14 +67,14 @@ services:
     networks:
       - web
     volumes:
-      - ./services/discord/.env:/usr/mount.d/.env
+      - ./server/services/discord/.env:/usr/mount.d/.env
   
   service-spotify:
     env_file:
       - .env
     container_name: area-service-spotify
     build:
-      context: ./services/spotify
+      context: ./server/services/spotify
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.spotify.rule=PathPrefix(`/service/spotify/`)"
@@ -97,7 +97,7 @@ services:
       - .env
     container_name: area-service-outlook
     build:
-      context: ./services/outlook
+      context: ./server/services/outlook
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.outlook.rule=PathPrefix(`/service/outlook/`)"
@@ -120,7 +120,7 @@ services:
       - .env
     container_name: area-service-time
     build:
-      context: ./services/time
+      context: ./server/services/time
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.time.rule=PathPrefix(`/service/time/`)"
@@ -141,7 +141,7 @@ services:
       - .env
     container_name: area-service-roblox
     build:
-      context: ./services/roblox
+      context: ./server/services/roblox
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.roblox.rule=PathPrefix(`/service/roblox/`)"
@@ -157,14 +157,14 @@ services:
     networks:
       - web
     volumes:
-    - ./services/roblox/.env:/usr/mount.d/.env
+    - ./server/services/roblox/.env:/usr/mount.d/.env
   
   service-github:
     env_file:
       - .env
     container_name: area-service-github
     build:
-      context: ./services/github
+      context: ./server/services/github
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.github.rule=PathPrefix(`/service/github/`)"
@@ -180,14 +180,14 @@ services:
     networks:
       - web
     volumes:
-    - ./services/github/.env:/usr/mount.d/.env
+    - ./server/services/github/.env:/usr/mount.d/.env
   
   service-reddit:
     env_file:
       - .env
     container_name: area-service-reddit
     build:
-      context: ./services/reddit
+      context: ./server/services/reddit
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.reddit.rule=PathPrefix(`/service/reddit/`)"

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     env_file:
       - .env
     build:
-      context: ./src
+      context: ./server/src
     ports:
       - ${BACKEND_PORT}:${BACKEND_PORT}
     depends_on:
@@ -39,8 +39,8 @@ services:
       - POSTGRES_USER=${DATABASE_USER}
       - POSTGRES_DB=${DATABASE_NAME}
     volumes:
-      - ./database/setup.sql:/docker-entrypoint-initdb.d/setup.sql
-      - ./database/time.sql:/docker-entrypoint-initdb.d/time.sql
+      - ./server/database/setup.sql:/docker-entrypoint-initdb.d/setup.sql
+      - ./server/database/time.sql:/docker-entrypoint-initdb.d/time.sql
     networks:
       - web
     

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     env_file:
       - .env
     build:
-      context: ./server/src
+      context: ./src
     ports:
       - ${BACKEND_PORT}:${BACKEND_PORT}
     depends_on:
@@ -22,7 +22,7 @@ services:
     networks:
       - web
     volumes:
-      - ./server/services:${BACKEND_SERVICES_PATH}
+      - ./services:${BACKEND_SERVICES_PATH}
 
   database:
     env_file:
@@ -39,8 +39,8 @@ services:
       - POSTGRES_USER=${DATABASE_USER}
       - POSTGRES_DB=${DATABASE_NAME}
     volumes:
-      - ./server/database/setup.sql:/docker-entrypoint-initdb.d/setup.sql
-      - ./server/database/time.sql:/docker-entrypoint-initdb.d/time.sql
+      - ./database/setup.sql:/docker-entrypoint-initdb.d/setup.sql
+      - ./database/time.sql:/docker-entrypoint-initdb.d/time.sql
     networks:
       - web
     
@@ -49,7 +49,7 @@ services:
       - .env
     container_name: area-service-discord
     build:
-      context: ./server/services/discord
+      context: ./services/discord
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.discord.rule=PathPrefix(`/service/discord/`)"
@@ -67,14 +67,14 @@ services:
     networks:
       - web
     volumes:
-      - ./server/services/discord/.env:/usr/mount.d/.env
+      - ./services/discord/.env:/usr/mount.d/.env
   
   service-spotify:
     env_file:
       - .env
     container_name: area-service-spotify
     build:
-      context: ./server/services/spotify
+      context: ./services/spotify
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.spotify.rule=PathPrefix(`/service/spotify/`)"
@@ -97,7 +97,7 @@ services:
       - .env
     container_name: area-service-outlook
     build:
-      context: ./server/services/outlook
+      context: ./services/outlook
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.outlook.rule=PathPrefix(`/service/outlook/`)"
@@ -120,7 +120,7 @@ services:
       - .env
     container_name: area-service-time
     build:
-      context: ./server/services/time
+      context: ./services/time
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.time.rule=PathPrefix(`/service/time/`)"
@@ -141,7 +141,7 @@ services:
       - .env
     container_name: area-service-roblox
     build:
-      context: ./server/services/roblox
+      context: ./services/roblox
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.roblox.rule=PathPrefix(`/service/roblox/`)"
@@ -157,14 +157,14 @@ services:
     networks:
       - web
     volumes:
-    - ./server/services/roblox/.env:/usr/mount.d/.env
+    - ./services/roblox/.env:/usr/mount.d/.env
   
   service-github:
     env_file:
       - .env
     container_name: area-service-github
     build:
-      context: ./server/services/github
+      context: ./services/github
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.github.rule=PathPrefix(`/service/github/`)"

--- a/server/services/discord/main.go
+++ b/server/services/discord/main.go
@@ -288,7 +288,8 @@ func getRoutes(w http.ResponseWriter, req *http.Request) {
 		},
 	}
 	var infos = Infos{
-		Color: "#ffff0000",
+		Color: "#5865F2",
+		Image: "https://cdn.prod.website-files.com/6257adef93867e50d84d30e2/636e0a6ca814282eca7172c6_icon_clyde_white_RGB.svg",
 		Routes: list,
 	}
 	var data []byte

--- a/server/services/discord/main.go
+++ b/server/services/discord/main.go
@@ -315,6 +315,6 @@ func main() {
 	router.HandleFunc("/send", doSomeSend).Methods("POST")
 	router.HandleFunc("/oauth", getOAUTHLink).Methods("GET")
 	router.HandleFunc("/oauth", miniproxy(setOAUTHToken, db)).Methods("POST")
-	router.HandleFunc("/routes", getRoutes).Methods("GET")
+	router.HandleFunc("/", getRoutes).Methods("GET")
 	log.Fatal(http.ListenAndServe(":80", router))
 }

--- a/server/services/discord/main.go
+++ b/server/services/discord/main.go
@@ -289,7 +289,7 @@ func getRoutes(w http.ResponseWriter, req *http.Request) {
 	}
 	var infos = Infos{
 		Color: "#5865F2",
-		Image: "https://cdn.prod.website-files.com/6257adef93867e50d84d30e2/636e0a6ca814282eca7172c6_icon_clyde_white_RGB.svg",
+		Image: "https://cdn.prod.website-files.com/6257adef93867e50d84d30e2/636e0a6cc3c481a15a141738_icon_clyde_white_RGB.png",
 		Routes: list,
 	}
 	var data []byte

--- a/server/services/discord/main.go
+++ b/server/services/discord/main.go
@@ -263,8 +263,8 @@ type InfoRoute struct {
 
 type Infos struct {
 	Color string `json:"color"`
-	Image string `json:"Image"`
-	Routes []InfoRoute `json:"routes"`
+	Image string `json:"image"`
+	Routes []InfoRoute `json:"areas"`
 }
 
 func getRoutes(w http.ResponseWriter, req *http.Request) {

--- a/server/services/github/app.py
+++ b/server/services/github/app.py
@@ -119,7 +119,7 @@ app = Flask(__name__)
 # github color and image
 oreo = NewOreo(
 	service="github",
-	color="#ff4500",
+	color="#24292e",
 	image="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
 )
 

--- a/server/services/outlook/main.go
+++ b/server/services/outlook/main.go
@@ -96,8 +96,8 @@ func setOAUTHToken(w http.ResponseWriter, req *http.Request, db *sql.DB) {
 	data.Set("redirect_uri", os.Getenv("REDIRECT"))
 	rep, err := http.PostForm(API_OAUTH_OUTLOOK, data)
 	body, err := io.ReadAll(rep.Body)
+	fmt.Println(clientsecret)
 	fmt.Fprintln(w, "tmp = ", string(body))
-	return
 	if err != nil {
 		fmt.Fprintln(w, "postform", err.Error())
 		return
@@ -120,7 +120,7 @@ func setOAUTHToken(w http.ResponseWriter, req *http.Request, db *sql.DB) {
 	}
 	fmt.Println(responseData)
 	tok.Token = responseData["access_token"].(string)
-	tok.Refresh = responseData["refresh_token"].(string)
+	tok.Refresh = "foobar"
 
 	req, err = http.NewRequest("GET", API_USER_OUTLOOK, nil)
 	if err != nil {
@@ -520,13 +520,13 @@ func getRoutes(w http.ResponseWriter, req *http.Request) {
 }
 
 func main() {
+	godotenv.Load(".env")
 	db, err := connectToDatabase()
 	if err != nil {
 		os.Exit(84)
 	}
 	fmt.Println("outlook microservice container is running !")
 	router := mux.NewRouter()
-	godotenv.Load(".env")
 	//router.HandleFunc("/send", doSomeSend).Methods("POST")
 	router.HandleFunc("/oauth", getOAUTHLink).Methods("GET")
 	router.HandleFunc("/oauth", miniproxy(setOAUTHToken, db)).Methods("POST")

--- a/server/services/time/main.go
+++ b/server/services/time/main.go
@@ -166,11 +166,13 @@ func miniProxy(f func(http.ResponseWriter, *http.Request, *sql.DB), c *sql.DB) f
 
 type Message struct {
 	Bridge int `json:"bridge"`
+	Ingredients map[string]string `json:"ingredients"`
 }
 
 func masterThread(db *sql.DB) {
 	var msg Message
 
+	msg.Ingredients = make(map[string]string)
 	client := http.Client{}
 	backendPort := os.Getenv("BACKEND_PORT")
 	if backendPort == "" {
@@ -207,8 +209,10 @@ func masterThread(db *sql.DB) {
 		if err := rows.Err(); err != nil {
 			continue
 		}
+		formatTime := timestamp.Format("2006-01-02 15:04:05")
 		for _, v := range bridges {
 			msg.Bridge = v
+			msg.Ingredients["time"] = formatTime
 			obj, err := json.Marshal(msg)
 			if err != nil {
 				continue

--- a/server/services/time/main.go
+++ b/server/services/time/main.go
@@ -308,6 +308,6 @@ func main() {
 	fmt.Println("time microservice container is running !")
 	router := mux.NewRouter()
 	router.HandleFunc("/in", miniProxy(timeIn, db)).Methods("POST")
-	router.HandleFunc("/routes", getRoutes).Methods("GET")
+	router.HandleFunc("/", getRoutes).Methods("GET")
 	log.Fatal(http.ListenAndServe(":80", router))
 }

--- a/server/services/time/main.go
+++ b/server/services/time/main.go
@@ -283,7 +283,7 @@ func getRoutes(w http.ResponseWriter, req *http.Request) {
 		},
 	}
 	var infos = Infos{
-		Color: "#ff0000ff",
+		Color: "#ffffff",
 		Routes: list,
 	}
 	var data []byte

--- a/server/services/time/main.go
+++ b/server/services/time/main.go
@@ -251,8 +251,8 @@ type InfoRoute struct {
 
 type Infos struct {
 	Color string `json:"color"`
-	Image string `json:"Image"`
-	Routes []InfoRoute `json:"routes"`
+	Image string `json:"image"`
+	Routes []InfoRoute `json:"areas"`
 }
 
 func getRoutes(w http.ResponseWriter, req *http.Request) {

--- a/server/services/time/main.go
+++ b/server/services/time/main.go
@@ -284,6 +284,7 @@ func getRoutes(w http.ResponseWriter, req *http.Request) {
 	}
 	var infos = Infos{
 		Color: "#ffffff",
+		Image: "https://img.icons8.com/ios/452/timer.png",
 		Routes: list,
 	}
 	var data []byte

--- a/server/src/area/area.go
+++ b/server/src/area/area.go
@@ -29,6 +29,7 @@ type AboutClient struct {
 type AboutSevice struct {
 	Name string `json:"name"`
 	Icon string `json:"icon"`
+	Color string `json:"color"`
 	Actions []AboutSomething `json:"actions"`
 	Reactions []AboutSomething `json:"reactions"`
 }
@@ -70,8 +71,8 @@ type InfoRoute struct {
 
 type Infos struct {
 	Color string `json:"color"`
-	Image string `json:"Image"`
-	Routes []InfoRoute `json:"routes"`
+	Image string `json:"image"`
+	Routes []InfoRoute `json:"areas"`
 }
 
 func (it *Area) ObserveServices(where string) error {
@@ -90,6 +91,7 @@ func (it *Area) SetupTheAbout() error {
 	var revproxy = os.Getenv("REVERSEPROXY_PORT")
 	var infos Infos
 	var tmpService AboutSevice
+	var something AboutSomething
 
 	it.About = About{
 		Client: AboutClient{
@@ -117,17 +119,26 @@ func (it *Area) SetupTheAbout() error {
 			fmt.Printf("reeadall of %s failed: %s\n", service, err.Error())
 			continue
 		}
-		fmt.Printf("%s: (%s)\n", url, body)
+		// fmt.Printf("%s: (%s)\n", url, body)
 		err = json.Unmarshal(body, &infos)
 		if err != nil {
 			fmt.Printf("decoding %s failed: %s body is %s\n", service, err.Error(), rep.Body)
 			continue
 		}
+		tmpService.Actions = []AboutSomething{}
+		tmpService.Reactions = []AboutSomething{}
 		for _, v := range infos.Routes {
+			something.Description = v.Desc
+			something.Name = v.Name
 			if v.Type == "action" {
-				tmpService.Actions = append(tmpService.Actions, )
+				tmpService.Actions = append(tmpService.Actions, something)
+			} else {
+				tmpService.Reactions = append(tmpService.Reactions, something)
 			}
 		}
+		tmpService.Name = service
+		tmpService.Icon = infos.Image
+		tmpService.Color = infos.Color
 		it.About.Server.Services = append(it.About.Server.Services, tmpService)
 	}
 	return nil

--- a/server/src/area/area.go
+++ b/server/src/area/area.go
@@ -17,9 +17,17 @@ const expiration = 60 * 30
 
 // the about structure (for about.json)
 
+type AboutSpice struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Title string `json:"title"`
+	Extra []string `json:"extra"`
+}
+
 type AboutSomething struct {
 	Name string `json:"name"`
 	Description string `json:"description"`
+	Spices []AboutSpice `json:"spices"`
 }
 
 type AboutClient struct {
@@ -55,18 +63,11 @@ type Area struct {
 
 // for the informations i get from the services
 
-type InfoSpice struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
-	Title string `json:"title"`
-	Extra []string `json:"extra"`
-}
-
 type InfoRoute struct {
 	Type string `json:"type"`
 	Name string `json:"name"`
 	Desc string `json:"description"`
-	Spices []InfoSpice `json:"spices"`
+	Spices []AboutSpice `json:"spices"`
 }
 
 type Infos struct {
@@ -130,6 +131,8 @@ func (it *Area) SetupTheAbout() error {
 		for _, v := range infos.Routes {
 			something.Description = v.Desc
 			something.Name = v.Name
+			something.Spices = make([]AboutSpice, len(v.Spices))
+			copy(something.Spices, v.Spices)
 			if v.Type == "action" {
 				tmpService.Actions = append(tmpService.Actions, something)
 			} else {

--- a/server/src/backend.go
+++ b/server/src/backend.go
@@ -304,15 +304,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	err = a.SetupTheAbout()
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	corsMiddleware := handlers.CORS(
-		handlers.AllowedOrigins([]string{"*"}),
-		handlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE"}),
-		handlers.AllowedHeaders([]string{"Content-Type", "Authorization"}),
-	)
+    corsMiddleware := handlers.CORS(
+        handlers.AllowedOrigins([]string{"*"}),
+        handlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE"}),
+        handlers.AllowedHeaders([]string{"Content-Type", "Authorization"}),
+    )
 	router.HandleFunc("/api/login", newProxy(&a, auth.DoSomeLogin)).Methods("POST")
 	router.HandleFunc("/api/register", newProxy(&a, auth.DoSomeRegister)).Methods("POST")
 	router.HandleFunc("/api/area", newProxy(&a, arearoute.NewArea)).Methods("POST")
@@ -328,6 +324,12 @@ func main() {
 	router.HandleFunc("/api/change", newProxy(&a, auth.DoSomeChangePassword)).Methods("PUT")
 	router.HandleFunc("/about.json", newProxy(&a, createTheAbout)).Methods("GET")
 
-	fmt.Println("=> server listens on port ", portString)
-	log.Fatal(http.ListenAndServe(":"+portString, corsMiddleware(router)))
+    fmt.Println("=> server listens on port ", portString)
+	time.Sleep(time.Second)
+	err = a.SetupTheAbout()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+    log.Fatal(http.ListenAndServe(":"+portString, corsMiddleware(router)))
+
 }

--- a/server/src/backend.go
+++ b/server/src/backend.go
@@ -325,7 +325,7 @@ func main() {
 	router.HandleFunc("/about.json", newProxy(&a, createTheAbout)).Methods("GET")
 
     fmt.Println("=> server listens on port ", portString)
-	time.Sleep(time.Second)
+	time.Sleep(time.Second * 2)
 	err = a.SetupTheAbout()
 	if err != nil {
 		log.Fatal(err.Error())

--- a/server/src/backend.go
+++ b/server/src/backend.go
@@ -214,8 +214,23 @@ func codeCallback(a area.AreaRequest) {
 	}, http.StatusOK)
 }
 
+type MiniAbout struct {
+	Color string `json:"color"`
+	Name string `json:"name"`
+	Image string `json:"image"`
+}
+
 func getAllServices(a area.AreaRequest) {
-	a.Reply(a.Area.Services, http.StatusOK)
+	var tmp MiniAbout
+	services := []MiniAbout{}
+	
+	for _, v := range a.Area.About.Server.Services {
+		tmp.Color = v.Color
+		tmp.Image = v.Icon
+		tmp.Name = v.Name
+		services = append(services, tmp)
+	}
+	a.Reply(services, http.StatusOK)
 }
 
 func createTheAbout(a area.AreaRequest) {

--- a/server/src/routes/arearoute/newarea.go
+++ b/server/src/routes/arearoute/newarea.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"area-backend/area"
 	"os"
@@ -124,13 +124,13 @@ func NewArea(a area.AreaRequest) {
 		return
 	}
 	defer rep.Body.Close()
-	body, err := ioutil.ReadAll(rep.Body)
+	body, err := io.ReadAll(rep.Body)
 	if err != nil {
 		a.Error(err, http.StatusInternalServerError)
 		return
 	}
 	a.Reply(map[string]any{
-		"res": "Your email is send" + string(body) + " " + string(id),
+		"status": "ok",
+		"body": string(body),
 	}, http.StatusOK)
-	// fmt.Fprintf(a.Writter, "Your email is %d, Awnser is %s", id, string(body))
 }

--- a/server/src/routes/arearoute/newarea.go
+++ b/server/src/routes/arearoute/newarea.go
@@ -24,6 +24,7 @@ type Bridge struct {
 type ToSend struct {
 	Spices json.RawMessage `json:"spices"`
 	Bridge int `json:"bridge"`
+	Id int `json:"userid"`
 }
 
 func createActionReaction(a area.AreaRequest, bridge Bridge) int {
@@ -101,6 +102,7 @@ func NewArea(a area.AreaRequest) {
 		return
 	}
 	tosend.Spices = bridge.Action.Spices
+	tosend.Id = id
 	url := fmt.Sprintf("http://reverse-proxy:%s/service/%s/%s",
 		os.Getenv("REVERSEPROXY_PORT"),
 		bridge.Action.Service,


### PR DESCRIPTION
mega push of doom

it includes
- ingredients feeature
- mega fix of a lot of errors in microservices & backend in general
- create the `PUT /api/change` to change password
- change all hard coded ports to env variables
- make all `:80/routes` be `:80`
- add descriptions about spices and services
- add color and images in my microservices
- send userid in the actions
- open `/api/services/???/webhook` so it redireects to the service `???:80/webhook`
- make a better `/api/services`
- make a generic way to get all services

## MAJOR CHANGES -- TO READ
1. Now, the route on your microservices `/` must have all microservices and spice, example:
```json
// GET /api/services/discord/
{
    "color": "#5865F2",
    "image": "https://cdn.prod.website-files.com/6257adef93867e50d84d30e2/636e0a6cc3c481a15a141738_icon_clyde_white_RGB.png",
    "areas": [
        {
            "type": "reaction",
            "name": "send",
            "description": "Sends a message in a channel.",
            "spices": [
                {
                    "name": "channel",
                    "type": "number",
                    "title": "The discord channel id.",
                    "extra": null
                },
                {
                    "name": "message",
                    "type": "text",
                    "title": "The message you want to send.",
                    "extra": null
                }
            ]
        }
    ]
}
```

2. When you PUT to an orchestrator (after an action is completed) you **MUST** include absolutely `userid` & `ingredients`, even if its an empty dictionnary, plus the `bridge` you was originally sending, example
```json
// PUT /api/orchestrator
{
  "bridge": 1,
  "userid": 42,
  "ingredients": {}
}
```
if you wanna send ingredients, here is an example on how you would do it:
```json
// PUT /api/orchestrator
{
  "bridge": 1,
  "userid": 42,
  "ingredients": {
    "name": "paul"
  }
}